### PR TITLE
docs: add CadFlow Harness badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@
   <img alt="OpenCascade 7.9.3" src="https://img.shields.io/badge/OpenCascade-7.9.3-334155">
   <img alt="Platform Linux x86-64" src="https://img.shields.io/badge/Platform-Linux%20x86--64-FCC624?logo=linux&logoColor=black">
   <a href="http://119.28.82.252/"><img alt="Documentation" src="https://img.shields.io/badge/Docs-Online-2563EB?logo=readthedocs&logoColor=white"></a>
+  <a href="https://github.com/zion-zion-zion/CadFlow-Harness"><img alt="CadFlow-Harness repository" src="https://img.shields.io/badge/CadFlow--Harness-GitHub-181717?logo=github&logoColor=white"></a>
   <a href="LICENSE"><img alt="License MIT" src="https://img.shields.io/badge/License-MIT-0F766E"></a>
   <img alt="Status Alpha" src="https://img.shields.io/badge/Status-Alpha-F59E0B">
 </p>
@@ -146,7 +147,7 @@ validated CAD / Scene artifact
 
 The repository includes progressively disclosed [CAD Skills](skills/) for rigid-part modeling, flexible geometry, STEP/BREP reconstruction, validated export, and real-time preview. They give an agent task-specific workflows and exact API references without loading the entire CAD surface into every prompt.
 
-[CadFlowAgent](https://github.com/zion-zion-zion/CadFlowAgent) is a separate application built on this boundary. It adds LLM harnesses, project workspaces, execution and repair loops, live progress, a browser viewer, and run records; CadFlow remains responsible for geometry, measurements, exchange, and Scene compilation.
+**CadFlow-Harness** is a separate application built on this boundary. It adds an LLM harness, project workspaces, execution and repair loops, live progress, a browser viewer, and run records; CadFlow remains responsible for geometry, measurements, exchange, and Scene compilation.
 
 > [!NOTE]
 > [`agent_dsl/`](agent_dsl/) is an isolated experimental layer for a compact, stateful command protocol. It can significantly reduce token consumption during generation, and we will continue to improve it in future releases.

--- a/README_zh.md
+++ b/README_zh.md
@@ -18,6 +18,7 @@
   <img alt="OpenCascade 7.9.3" src="https://img.shields.io/badge/OpenCascade-7.9.3-334155">
   <img alt="Platform Linux x86-64" src="https://img.shields.io/badge/Platform-Linux%20x86--64-FCC624?logo=linux&logoColor=black">
   <a href="http://119.28.82.252/"><img alt="在线文档" src="https://img.shields.io/badge/Docs-Online-2563EB?logo=readthedocs&logoColor=white"></a>
+  <a href="https://github.com/zion-zion-zion/CadFlow-Harness"><img alt="CadFlow-Harness 仓库" src="https://img.shields.io/badge/CadFlow--Harness-GitHub-181717?logo=github&logoColor=white"></a>
   <a href="LICENSE"><img alt="License MIT" src="https://img.shields.io/badge/License-MIT-0F766E"></a>
   <img alt="Status Alpha" src="https://img.shields.io/badge/Status-Alpha-F59E0B">
 </p>
@@ -156,7 +157,7 @@ CadFlow 构建并检查确定性几何
 
 仓库提供按需展开的 [CAD Skills](skills/)，覆盖刚性零件建模、柔性几何、STEP/BREP 重建、验证导出和实时预览。智能体可以只加载当前任务需要的工作流和准确 API 参考，而不必在每次提示中塞入完整 CAD 手册。
 
-[CadFlowAgent](https://github.com/zion-zion-zion/CadFlowAgent) 是基于这一边界构建的独立上层应用。它提供 LLM Harness、项目工作区、执行与修复循环、实时进度、浏览器 Viewer 和运行记录；CadFlow 则负责几何、测量、数据交换和 Scene 编译。
+**CadFlow-Harness** 是基于这一边界构建的独立上层应用。它提供 LLM Harness、项目工作区、执行与修复循环、实时进度、浏览器 Viewer 和运行记录；CadFlow 则负责几何、测量、数据交换和 Scene 编译。
 
 > [!NOTE]
 > [`agent_dsl/`](agent_dsl/) 是用于紧凑有状态指令协议的隔离实验层，它可以大幅度减少生成过程的token消耗，我们将在后续版本逐步优化。


### PR DESCRIPTION
## Summary

- add a CadFlow-Harness GitHub badge beside the documentation badge
- update the English and Chinese application references
- keep the repository URL in the top badge area

## Verification

- confirmed the target repository exists
- confirmed the badge image returns HTTP 200
- ran `git diff --check`