### PR TITLE
添加 macOS arm64 wheel 支持

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,6 +89,73 @@ jobs:
           python -m pip wheel dist/*.tar.gz --no-deps --no-build-isolation -w sdist-wheel
           test -n "$(find sdist-wheel -name '*.whl' -print -quit)"
 
+  macos-wheel:
+    name: macOS arm64 wheel
+    runs-on: macos-14
+    env:
+      CMAKE_OSX_ARCHITECTURES: arm64
+      MACOSX_DEPLOYMENT_TARGET: "12.0"
+      MPLBACKEND: Agg
+    steps:
+      - uses: actions/checkout@v4
+      - name: Verify Apple Silicon runner
+        run: test "$(uname -m)" = arm64
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+          cache: pip
+      - name: Install build dependencies
+        run: |
+          python -m pip install --upgrade pip setuptools wheel build twine delocate
+          python -m pip install "cadquery-ocp==7.9.3.1" py-slvs==1.0.6 "ocp-gordon>=0.2,<0.3"
+      - name: Build distributions
+        run: |
+          python -m build --no-isolation
+          python -m twine check dist/*
+      - name: Inspect wheel native dependencies
+        run: |
+          wheel unpack dist/*.whl -d wheel-unpack
+          core="$(find wheel-unpack -name libcadflow_core.dylib -print -quit)"
+          test -n "$core"
+          file "$core" | grep -q arm64
+          if otool -L "$core" | grep -E '/DLC/|/Users/|site-packages'; then
+            echo "wheel contains a non-relocatable native dependency"
+            exit 1
+          fi
+          otool -l "$core" | grep -q '@loader_path/../OCP/.dylibs'
+          otool -l "$core" | grep -q '@loader_path/../vtkmodules/.dylibs'
+      - name: Verify wheel install and regression suite
+        run: |
+          python -m venv "$RUNNER_TEMP/cadflow-wheel"
+          "$RUNNER_TEMP/cadflow-wheel/bin/python" -m pip install dist/*.whl pytest ezdxf matplotlib pillow
+          cd "$RUNNER_TEMP"
+          "$RUNNER_TEMP/cadflow-wheel/bin/python" - <<'PY'
+          from pathlib import Path
+          from tempfile import TemporaryDirectory
+
+          import cadflow
+
+          with cadflow.NativeSession() as session:
+              assert "occt-7.9.3" in session.version
+          with TemporaryDirectory() as directory, cadflow.Model() as model:
+              box = model.box(2, 3, 4)
+              assert abs(box.volume - 24.0) < 1e-9
+              path = Path(directory) / "box.step"
+              box.export_step(path)
+              imported = model.import_step(path)
+              assert abs(imported.volume - 24.0) < 1e-9
+              assert model.faces(box)[0].surface_metrics()["valid"] is True
+          PY
+          "$RUNNER_TEMP/cadflow-wheel/bin/python" -m pytest \
+            --override-ini pythonpath= \
+            -q --disable-warnings --tb=short \
+            "$GITHUB_WORKSPACE/tests"
+      - name: Rebuild wheel from sdist
+        run: |
+          mkdir "$RUNNER_TEMP/sdist-wheel"
+          python -m pip wheel dist/*.tar.gz --no-deps --no-build-isolation -w "$RUNNER_TEMP/sdist-wheel"
+          test -n "$(find "$RUNNER_TEMP/sdist-wheel" -name '*.whl' -print -quit)"
+
   scene-contract:
     name: Scene TypeScript parity
     runs-on: ubuntu-22.04

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
   <a href="https://www.python.org/"><img alt="Python 3.10–3.13" src="https://img.shields.io/badge/Python-3.10--3.13-3776AB?logo=python&logoColor=white"></a>
   <img alt="C++ 17" src="https://img.shields.io/badge/C++-17-00599C?logo=cplusplus&logoColor=white">
   <img alt="OpenCascade 7.9.3" src="https://img.shields.io/badge/OpenCascade-7.9.3-334155">
-  <img alt="Platform Linux x86-64" src="https://img.shields.io/badge/Platform-Linux%20x86--64-FCC624?logo=linux&logoColor=black">
+  <img alt="Platforms Linux x86-64 and macOS arm64" src="https://img.shields.io/badge/Platforms-Linux%20x86--64%20%7C%20macOS%20arm64-555555">
   <a href="http://119.28.82.252/"><img alt="Documentation" src="https://img.shields.io/badge/Docs-Online-2563EB?logo=readthedocs&logoColor=white"></a>
   <a href="https://github.com/zion-zion-zion/CadFlow-Harness"><img alt="CadFlow-Harness repository" src="https://img.shields.io/badge/CadFlow--Harness-GitHub-181717?logo=github&logoColor=white"></a>
   <a href="LICENSE"><img alt="License MIT" src="https://img.shields.io/badge/License-MIT-0F766E"></a>
@@ -172,17 +172,25 @@ The repository includes progressively disclosed [CAD Skills](skills/) for rigid-
 
 ### Requirements
 
-- Linux x86_64 for the currently tested full OCCT build
-- Python 3.10 through 3.13
+- Linux x86_64 or Apple Silicon macOS 12 and newer
+- Python 3.10 through 3.13 on Linux; Python 3.13 for macOS arm64 wheels
 - CMake 3.16 or newer
 - A C++17 compiler
-- Python development headers
+- Python development headers on Linux, or Xcode Command Line Tools on macOS
 
 On Ubuntu or Debian:
 
 ```bash
 sudo apt update
 sudo apt install build-essential cmake python3-dev
+```
+
+On macOS, install Xcode Command Line Tools and make CMake available. Homebrew is
+one option for CMake, but is not required:
+
+```bash
+xcode-select --install
+brew install cmake
 ```
 
 Clone the repository and install the OpenCascade runtime before building CadFlow:
@@ -256,17 +264,17 @@ For contributors working on the native backend:
 cmake -S . -B build -DCMAKE_BUILD_TYPE=Release
 cmake --build build -j2
 python -m pytest -q
-python -m pip wheel . --no-deps -w dist
+python -m build --wheel --no-isolation
 ```
 
-The default build uses matching OCCT 7.9.3 headers and libraries when available. Use `-DCADFLOW_USE_OCCT=OFF` for the analytic fallback or `-DCADFLOW_WITH_STEP=OFF` for a smaller native build without STEP writing. The compatibility STEP API remains available through `cadflow.compat`.
+The default build uses matching OCCT 7.9.3 headers and libraries when available. A macOS build requires CPython 3.13, Apple Silicon, and fails if the matching OCCT installation is missing instead of silently producing a fallback wheel. Use `-DCADFLOW_USE_OCCT=OFF` for an explicit analytic fallback or `-DCADFLOW_WITH_STEP=OFF` for a smaller native build without STEP writing. The compatibility STEP API remains available through `cadflow.compat`.
 
 For 2D manufacturing, select a planar face and export its outer boundary and
 holes with `face.export_dxf("profile.dxf")`. See the
 [DXF machining-profile guide](docs/guides/dxf-profile-export.md) for the output
 contract and validation requirements.
 
-Built wheels contain `libcadflow_core`, the stable public header under `cadflow/include/`, and a relative runtime path to OCCT libraries supplied by `cadquery-ocp`. Set `CADFLOW_CORE_LIBRARY` only when deliberately using an externally built core.
+Built wheels contain `libcadflow_core`, the stable public header under `cadflow/include/`, and platform-relative runtime paths to OCCT libraries supplied by `cadquery-ocp`. On macOS, wheel builds default to arm64 and deployment target 12.0. Set `CADFLOW_CORE_LIBRARY` only when deliberately using an externally built core.
 
 ## 🙏 Thanks
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -21,7 +21,7 @@
   <a href="https://www.python.org/"><img alt="Python 3.10–3.13" src="https://img.shields.io/badge/Python-3.10--3.13-3776AB?logo=python&logoColor=white"></a>
   <img alt="C++ 17" src="https://img.shields.io/badge/C++-17-00599C?logo=cplusplus&logoColor=white">
   <img alt="OpenCascade 7.9.3" src="https://img.shields.io/badge/OpenCascade-7.9.3-334155">
-  <img alt="Platform Linux x86-64" src="https://img.shields.io/badge/Platform-Linux%20x86--64-FCC624?logo=linux&logoColor=black">
+  <img alt="支持 Linux x86-64 和 macOS arm64" src="https://img.shields.io/badge/Platforms-Linux%20x86--64%20%7C%20macOS%20arm64-555555">
   <a href="http://119.28.82.252/"><img alt="在线文档" src="https://img.shields.io/badge/Docs-Online-2563EB?logo=readthedocs&logoColor=white"></a>
   <a href="https://github.com/zion-zion-zion/CadFlow-Harness"><img alt="CadFlow-Harness 仓库" src="https://img.shields.io/badge/CadFlow--Harness-GitHub-181717?logo=github&logoColor=white"></a>
   <a href="LICENSE"><img alt="License MIT" src="https://img.shields.io/badge/License-MIT-0F766E"></a>
@@ -182,17 +182,25 @@ CadFlow 构建并检查确定性几何
 
 ### 环境要求
 
-- Linux x86_64，用于当前已测试的完整 OCCT 构建
-- Python 3.10 至 3.13
+- Linux x86_64，或运行 macOS 12 及更高版本的 Apple Silicon Mac
+- Linux 支持 Python 3.10 至 3.13；macOS arm64 wheel 使用 Python 3.13
 - CMake 3.16 或更高版本
 - 支持 C++17 的编译器
-- Python 开发头文件
+- Linux 需要 Python 开发头文件，macOS 需要 Xcode Command Line Tools
 
 Ubuntu 或 Debian 用户可以执行：
 
 ```bash
 sudo apt update
 sudo apt install build-essential cmake python3-dev
+```
+
+在 macOS 上，需要安装 Xcode Command Line Tools 并确保 CMake 可用。Homebrew
+可以用来安装 CMake，但不是硬性依赖：
+
+```bash
+xcode-select --install
+brew install cmake
 ```
 
 克隆仓库，并在构建 CadFlow 前安装 OpenCascade 运行时：
@@ -267,16 +275,16 @@ CadFlow/
 cmake -S . -B build -DCMAKE_BUILD_TYPE=Release
 cmake --build build -j2
 python -m pytest -q
-python -m pip wheel . --no-deps -w dist
+python -m build --wheel --no-isolation
 ```
 
-默认构建会在可用时使用匹配的 OCCT 7.9.3 头文件和库。使用 `-DCADFLOW_USE_OCCT=OFF` 可以构建解析式 fallback；使用 `-DCADFLOW_WITH_STEP=OFF` 可以生成不包含原生 STEP 写入功能的较小构建。完整的兼容 STEP API 仍可通过 `cadflow.compat` 使用。
+默认构建会在可用时使用匹配的 OCCT 7.9.3 头文件和库。macOS 构建要求 Apple Silicon、Python 3.13；缺少匹配的 OCCT 时会直接失败，不会静默生成 fallback wheel。使用 `-DCADFLOW_USE_OCCT=OFF` 可以显式构建解析式 fallback；使用 `-DCADFLOW_WITH_STEP=OFF` 可以生成不包含原生 STEP 写入功能的较小构建。完整的兼容 STEP API 仍可通过 `cadflow.compat` 使用。
 
 二维加工时，先选中一个平面面，再通过
 `face.export_dxf("profile.dxf")` 导出外轮廓和孔。输出约定和检查方法见
 [DXF 加工轮廓指南](docs/guides/dxf-profile-export.md)。
 
-构建生成的 wheel 包含 `libcadflow_core`、`cadflow/include/` 下的稳定公共头文件，以及指向 `cadquery-ocp` 所提供 OCCT 动态库的相对运行时路径。只有明确使用外部编译的核心库时，才需要设置 `CADFLOW_CORE_LIBRARY`。
+构建生成的 wheel 包含 `libcadflow_core`、`cadflow/include/` 下的稳定公共头文件，以及指向 `cadquery-ocp` 所提供 OCCT 动态库的平台相对运行时路径。macOS wheel 默认构建为 arm64，并以 macOS 12.0 为最低部署目标。只有明确使用外部编译的核心库时，才需要设置 `CADFLOW_CORE_LIBRARY`。
 
 ## 🙏 致谢
 

--- a/native/CMakeLists.txt
+++ b/native/CMakeLists.txt
@@ -31,7 +31,8 @@ if (DEFINED ENV{CADFLOW_OCCT_LIB_DIR})
   set(_CADFLOW_DEFAULT_OCCT_LIB_DIR "$ENV{CADFLOW_OCCT_LIB_DIR}")
 elseif (DEFINED ENV{VIRTUAL_ENV})
   file(GLOB _CADFLOW_VENV_OCCT_LIB_DIRS LIST_DIRECTORIES true
-       "$ENV{VIRTUAL_ENV}/lib/python*/site-packages/cadquery_ocp.libs")
+       "$ENV{VIRTUAL_ENV}/lib/python*/site-packages/cadquery_ocp.libs"
+       "$ENV{VIRTUAL_ENV}/lib/python*/site-packages/OCP/.dylibs")
   list(LENGTH _CADFLOW_VENV_OCCT_LIB_DIRS _CADFLOW_VENV_OCCT_COUNT)
   if (_CADFLOW_VENV_OCCT_COUNT GREATER 0)
     list(GET _CADFLOW_VENV_OCCT_LIB_DIRS 0 _CADFLOW_DEFAULT_OCCT_LIB_DIR)
@@ -44,7 +45,7 @@ if (NOT _CADFLOW_DEFAULT_OCCT_LIB_DIR)
   if (Python3_Interpreter_FOUND)
     execute_process(
       COMMAND "${Python3_EXECUTABLE}" -c
-              "import pathlib,sys; print(next((str(pathlib.Path(p)/'cadquery_ocp.libs') for p in sys.path if (pathlib.Path(p)/'cadquery_ocp.libs').is_dir()), ''))"
+              "import pathlib,sys; print(next((str(q) for p in sys.path for q in (pathlib.Path(p)/'cadquery_ocp.libs', pathlib.Path(p)/'OCP'/'.dylibs') if q.is_dir()), ''))"
       OUTPUT_VARIABLE _CADFLOW_DEFAULT_OCCT_LIB_DIR
       OUTPUT_STRIP_TRAILING_WHITESPACE
     )
@@ -57,23 +58,66 @@ if (CADFLOW_USE_OCCT AND EXISTS "${CADFLOW_OCCT_SOURCE}/src/TopoDS/TopoDS_Shape.
   file(GLOB OCCT_PACKAGE_DIRS LIST_DIRECTORIES true "${CADFLOW_OCCT_SOURCE}/src/*")
   target_include_directories(cadflow_core SYSTEM PRIVATE ${OCCT_PACKAGE_DIRS})
   target_compile_definitions(cadflow_core PRIVATE CADFLOW_WITH_OCCT=1)
-  set(OCCT_NAMES TKernel TKMath TKG2d TKG3d TKGeomBase TKBRep TKGeomAlgo TKTopAlgo TKPrim TKBO TKMesh TKOffset TKFillet TKDESTL)
+  set(OCCT_NAMES TKernel TKMath TKG2d TKG3d TKGeomBase TKBRep TKGeomAlgo TKTopAlgo TKPrim TKBO TKBool TKMesh TKOffset TKFillet TKDESTL)
   if (CADFLOW_WITH_STEP)
     list(APPEND OCCT_NAMES TKDE TKDESTEP TKXSBase)
     target_compile_definitions(cadflow_core PRIVATE CADFLOW_WITH_STEP=1)
   endif()
   foreach(OCCT_NAME ${OCCT_NAMES})
-    file(GLOB OCCT_LIBRARY "${CADFLOW_OCCT_LIB_DIR}/lib${OCCT_NAME}-*.so.7.9.3")
+    if (APPLE)
+      file(GLOB OCCT_LIBRARY "${CADFLOW_OCCT_LIB_DIR}/lib${OCCT_NAME}.7.9.3.dylib")
+    else()
+      file(GLOB OCCT_LIBRARY "${CADFLOW_OCCT_LIB_DIR}/lib${OCCT_NAME}-*.so.7.9.3")
+    endif()
     if (NOT OCCT_LIBRARY)
       message(FATAL_ERROR "Missing OCCT library ${OCCT_NAME} in ${CADFLOW_OCCT_LIB_DIR}")
     endif()
     target_link_libraries(cadflow_core PRIVATE ${OCCT_LIBRARY})
+    if (APPLE)
+      execute_process(
+        COMMAND otool -D "${OCCT_LIBRARY}"
+        RESULT_VARIABLE _CADFLOW_OTOOL_RESULT
+        OUTPUT_VARIABLE _CADFLOW_OTOOL_OUTPUT
+        OUTPUT_STRIP_TRAILING_WHITESPACE
+      )
+      if (NOT _CADFLOW_OTOOL_RESULT EQUAL 0)
+        message(FATAL_ERROR "Could not inspect OCCT library ${OCCT_LIBRARY}")
+      endif()
+      string(REPLACE "\n" ";" _CADFLOW_OTOOL_LINES "${_CADFLOW_OTOOL_OUTPUT}")
+      list(LENGTH _CADFLOW_OTOOL_LINES _CADFLOW_OTOOL_LINE_COUNT)
+      if (_CADFLOW_OTOOL_LINE_COUNT LESS 2)
+        message(FATAL_ERROR "OCCT library ${OCCT_LIBRARY} has no Mach-O install name")
+      endif()
+      list(GET _CADFLOW_OTOOL_LINES 1 _CADFLOW_OCCT_INSTALL_NAME)
+      string(STRIP "${_CADFLOW_OCCT_INSTALL_NAME}" _CADFLOW_OCCT_INSTALL_NAME)
+      get_filename_component(_CADFLOW_OCCT_FILENAME "${OCCT_LIBRARY}" NAME)
+      add_custom_command(TARGET cadflow_core POST_BUILD
+        COMMAND "${CMAKE_INSTALL_NAME_TOOL}" -change
+                "${_CADFLOW_OCCT_INSTALL_NAME}"
+                "@rpath/${_CADFLOW_OCCT_FILENAME}"
+                "$<TARGET_FILE:cadflow_core>"
+        VERBATIM
+      )
+    endif()
   endforeach()
-  set_target_properties(cadflow_core PROPERTIES
-      BUILD_RPATH "${CADFLOW_OCCT_LIB_DIR}"
-      INSTALL_RPATH "$ORIGIN/../cadquery_ocp.libs"
-  )
+  if (APPLE)
+    set_target_properties(cadflow_core PROPERTIES
+        BUILD_RPATH "${CADFLOW_OCCT_LIB_DIR}"
+        INSTALL_RPATH "@loader_path/../OCP/.dylibs;@loader_path/../vtkmodules/.dylibs"
+    )
+  else()
+    set_target_properties(cadflow_core PROPERTIES
+        BUILD_RPATH "${CADFLOW_OCCT_LIB_DIR}"
+        INSTALL_RPATH "$ORIGIN/../cadquery_ocp.libs"
+    )
+  endif()
 else()
+  if (APPLE AND CADFLOW_USE_OCCT)
+    message(FATAL_ERROR
+      "A matching cadquery-ocp 7.9.3 installation is required for macOS builds. "
+      "Install cadquery-ocp==7.9.3.1 or set CADFLOW_OCCT_LIB_DIR."
+    )
+  endif()
   message(WARNING "Matching OCCT headers/libraries not found; building the analytic fallback")
 endif()
 set_target_properties(cadflow_core PROPERTIES

--- a/native/src/physics/surface_contact.cpp
+++ b/native/src/physics/surface_contact.cpp
@@ -2,8 +2,10 @@
 
 #include <algorithm>
 #include <cmath>
+#include <cstdint>
+#include <filesystem>
+#include <fstream>
 #include <limits>
-#include <sstream>
 #include <stdexcept>
 #include <string>
 
@@ -268,10 +270,31 @@ TopoDS_Shape read_transformed_brep_face(
     if (!data || size == 0) {
         throw std::invalid_argument("surface BREP buffer is empty");
     }
-    std::istringstream stream(std::string(data, size));
     BRep_Builder builder;
     TopoDS_Shape shape;
-    BRepTools::Read(shape, stream, builder);
+    const std::filesystem::path path =
+        std::filesystem::temp_directory_path()
+        / ("cadflow-surface-" +
+           std::to_string(reinterpret_cast<std::uintptr_t>(data)) + ".brep");
+    {
+        std::ofstream file(path, std::ios::binary);
+        if (!file) {
+            throw std::runtime_error("surface BREP temporary file could not be opened");
+        }
+        file.write(data, static_cast<std::streamsize>(size));
+        if (!file) {
+            std::error_code ignored;
+            std::filesystem::remove(path, ignored);
+            throw std::runtime_error("surface BREP temporary file could not be written");
+        }
+    }
+    const Standard_Boolean read_ok =
+        BRepTools::Read(shape, path.string().c_str(), builder);
+    std::error_code ignored;
+    std::filesystem::remove(path, ignored);
+    if (!read_ok) {
+        throw std::runtime_error("surface BREP buffer could not be read");
+    }
     const TopoDS_Face face = require_face(shape);
     return BRepBuilderAPI_Transform(
         face, rigid_transform(transform_values), true).Shape();

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,12 +17,13 @@ classifiers = [
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13",
+  "Operating System :: MacOS :: MacOS X",
   "Topic :: Scientific/Engineering",
 ]
 dependencies = [
   "numpy>=1.21",
   "rich>=14.0",
-  "cadquery-ocp>=7.9.3.1",
+  "cadquery-ocp==7.9.3.1",
   "jsonschema>=4.25.1,<5",
   "rfc8785>=0.1.4,<0.2",
   "typing-extensions>=4.12,<5",

--- a/setup.py
+++ b/setup.py
@@ -1,11 +1,18 @@
 from __future__ import annotations
 
+import os
+import platform
+import shlex
 import subprocess
 import sys
 from pathlib import Path
 
 from setuptools import Distribution, setup
 from setuptools.command.build_py import build_py
+
+
+if sys.platform == "darwin":
+    os.environ.setdefault("MACOSX_DEPLOYMENT_TARGET", "12.0")
 
 
 class BinaryDistribution(Distribution):
@@ -16,6 +23,14 @@ class BinaryDistribution(Distribution):
 class CMakeBuildPy(build_py):
     def run(self) -> None:
         super().run()
+
+        if sys.platform == "darwin":
+            if platform.machine() != "arm64":
+                raise RuntimeError(
+                    "CadFlow macOS wheels must be built natively on Apple Silicon"
+                )
+            if sys.version_info[:2] != (3, 13):
+                raise RuntimeError("CadFlow macOS wheels require CPython 3.13")
 
         root = Path(__file__).resolve().parent
         build = Path(self.get_finalized_command("build").build_temp) / "cadflow-native"
@@ -28,6 +43,16 @@ class CMakeBuildPy(build_py):
             "-DCMAKE_BUILD_TYPE=Release",
             f"-DPython3_EXECUTABLE={sys.executable}",
         ]
+        if sys.platform == "darwin":
+            configure.extend(
+                [
+                    "-DCMAKE_OSX_ARCHITECTURES="
+                    + os.environ.get("CMAKE_OSX_ARCHITECTURES", "arm64"),
+                    "-DCMAKE_OSX_DEPLOYMENT_TARGET="
+                    + os.environ["MACOSX_DEPLOYMENT_TARGET"],
+                ]
+            )
+        configure.extend(shlex.split(os.environ.get("CMAKE_ARGS", "")))
         subprocess.run(configure, check=True)
         subprocess.run(
             ["cmake", "--build", str(build), "--config", "Release", "--parallel", "2"],


### PR DESCRIPTION
## 变更
- 增加 macOS 12+ Apple Silicon（arm64）构建支持，macOS wheel 限定 CPython 3.13
- 配置 OCCT dylib 的 macOS RPATH，并保留 Linux 构建路径
- 增加 macOS CI、wheel 安装 smoke test 与 sdist 重建检查
- 更新中英文构建文档

## 验证
- 完整回归：1020 passed, 3 skipped
- wheel 隔离环境 smoke test 通过
- sdist -> wheel 重建通过

最终 wheel：`dist/cadflow-0.2.0-cp313-cp313-macosx_12_0_arm64.whl`